### PR TITLE
Fix _LazyBatchNorm import broken by torch 1.10.0

### DIFF
--- a/onnx2pytorch/operations/batchnorm.py
+++ b/onnx2pytorch/operations/batchnorm.py
@@ -1,12 +1,19 @@
 import warnings
 
 from torch import nn
-from torch.nn.modules.batchnorm import _BatchNorm, _LazyNormBase
+from torch.nn.modules.batchnorm import _BatchNorm
+
+try:
+    from torch.nn.modules.batchnorm import _LazyNormBase
+
+    class _LazyBatchNorm(_LazyNormBase, _BatchNorm):
+
+        cls_to_become = _BatchNorm
 
 
-class _LazyBatchNorm(_LazyNormBase, _BatchNorm):
-
-    cls_to_become = _BatchNorm
+except ImportError:
+    # for torch < 1.10.0
+    from torch.nn.modules.batchnorm import _LazyBatchNorm
 
 
 class LazyBatchNormUnsafe(_LazyBatchNorm):

--- a/onnx2pytorch/operations/batchnorm.py
+++ b/onnx2pytorch/operations/batchnorm.py
@@ -1,7 +1,12 @@
 import warnings
 
 from torch import nn
-from torch.nn.modules.batchnorm import _BatchNorm, _LazyBatchNorm
+from torch.nn.modules.batchnorm import _BatchNorm, _LazyNormBase
+
+
+class _LazyBatchNorm(_LazyNormBase, _BatchNorm):
+
+    cls_to_become = _BatchNorm
 
 
 class LazyBatchNormUnsafe(_LazyBatchNorm):

--- a/onnx2pytorch/operations/instancenorm.py
+++ b/onnx2pytorch/operations/instancenorm.py
@@ -1,72 +1,13 @@
 import warnings
 import torch
 
+from torch.nn.modules.batchnorm import _LazyNormBase
 from torch.nn.modules.instancenorm import _InstanceNorm
-from torch.nn.modules.lazy import LazyModuleMixin
-from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
 
 
-class _LazyInstanceNorm(LazyModuleMixin, _InstanceNorm):
-
-    weight: UninitializedParameter  # type: ignore[assignment]
-    bias: UninitializedParameter  # type: ignore[assignment]
+class _LazyInstanceNorm(_LazyNormBase, _InstanceNorm):
 
     cls_to_become = _InstanceNorm
-
-    def __init__(
-        self,
-        eps=1e-5,
-        momentum=0.1,
-        affine=True,
-        track_running_stats=True,
-        device=None,
-        dtype=None,
-    ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
-        super(_LazyInstanceNorm, self).__init__(
-            # affine and track_running_stats are hardcoded to False to
-            # avoid creating tensors that will soon be overwritten.
-            0,
-            eps,
-            momentum,
-            False,
-            False,
-            **factory_kwargs,
-        )
-        self.affine = affine
-        self.track_running_stats = track_running_stats
-        if self.affine:
-            self.weight = UninitializedParameter(**factory_kwargs)
-            self.bias = UninitializedParameter(**factory_kwargs)
-        if self.track_running_stats:
-            self.running_mean = UninitializedBuffer(**factory_kwargs)
-            self.running_var = UninitializedBuffer(**factory_kwargs)
-            self.num_batches_tracked = torch.tensor(
-                0,
-                dtype=torch.long,
-                **{k: v for k, v in factory_kwargs.items() if k != "dtype"},
-            )
-
-    def reset_parameters(self) -> None:
-        if not self.has_uninitialized_params() and self.num_features != 0:
-            super().reset_parameters()
-
-    def initialize_parameters(self, input) -> None:  # type: ignore[override]
-        if self.has_uninitialized_params():
-            self.num_features = input.shape[1]
-            if self.affine:
-                assert isinstance(self.weight, UninitializedParameter)
-                assert isinstance(self.bias, UninitializedParameter)
-                self.weight.materialize((self.num_features,))
-                self.bias.materialize((self.num_features,))
-            if self.track_running_stats:
-                self.running_mean.materialize(
-                    (self.num_features,)
-                )  # type:ignore[union-attr]
-                self.running_var.materialize(
-                    (self.num_features,)
-                )  # type:ignore[union-attr]
-            self.reset_parameters()
 
 
 class LazyInstanceNormUnsafe(_LazyInstanceNorm):

--- a/onnx2pytorch/operations/instancenorm.py
+++ b/onnx2pytorch/operations/instancenorm.py
@@ -1,13 +1,81 @@
 import warnings
 import torch
 
-from torch.nn.modules.batchnorm import _LazyNormBase
 from torch.nn.modules.instancenorm import _InstanceNorm
 
+try:
+    from torch.nn.modules.batchnorm import _LazyNormBase
 
-class _LazyInstanceNorm(_LazyNormBase, _InstanceNorm):
+    class _LazyInstanceNorm(_LazyNormBase, _InstanceNorm):
 
-    cls_to_become = _InstanceNorm
+        cls_to_become = _InstanceNorm
+
+
+except ImportError:
+    from torch.nn.modules.lazy import LazyModuleMixin
+    from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
+
+    class _LazyInstanceNorm(LazyModuleMixin, _InstanceNorm):
+
+        weight: UninitializedParameter  # type: ignore[assignment]
+        bias: UninitializedParameter  # type: ignore[assignment]
+
+        cls_to_become = _InstanceNorm
+
+        def __init__(
+            self,
+            eps=1e-5,
+            momentum=0.1,
+            affine=True,
+            track_running_stats=True,
+            device=None,
+            dtype=None,
+        ) -> None:
+            factory_kwargs = {"device": device, "dtype": dtype}
+            super(_LazyInstanceNorm, self).__init__(
+                # affine and track_running_stats are hardcoded to False to
+                # avoid creating tensors that will soon be overwritten.
+                0,
+                eps,
+                momentum,
+                False,
+                False,
+                **factory_kwargs,
+            )
+            self.affine = affine
+            self.track_running_stats = track_running_stats
+            if self.affine:
+                self.weight = UninitializedParameter(**factory_kwargs)
+                self.bias = UninitializedParameter(**factory_kwargs)
+            if self.track_running_stats:
+                self.running_mean = UninitializedBuffer(**factory_kwargs)
+                self.running_var = UninitializedBuffer(**factory_kwargs)
+                self.num_batches_tracked = torch.tensor(
+                    0,
+                    dtype=torch.long,
+                    **{k: v for k, v in factory_kwargs.items() if k != "dtype"},
+                )
+
+        def reset_parameters(self) -> None:
+            if not self.has_uninitialized_params() and self.num_features != 0:
+                super().reset_parameters()
+
+        def initialize_parameters(self, input) -> None:  # type: ignore[override]
+            if self.has_uninitialized_params():
+                self.num_features = input.shape[1]
+                if self.affine:
+                    assert isinstance(self.weight, UninitializedParameter)
+                    assert isinstance(self.bias, UninitializedParameter)
+                    self.weight.materialize((self.num_features,))
+                    self.bias.materialize((self.num_features,))
+                if self.track_running_stats:
+                    self.running_mean.materialize(
+                        (self.num_features,)
+                    )  # type:ignore[union-attr]
+                    self.running_var.materialize(
+                        (self.num_features,)
+                    )  # type:ignore[union-attr]
+                self.reset_parameters()
 
 
 class LazyInstanceNormUnsafe(_LazyInstanceNorm):

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean,py36,py37,py38
+envlist = clean,py36,py37,py38,py38-torch19,py39
 
 [testenv]
 passenv =
@@ -12,6 +12,7 @@ passenv =
     KMP_DUPLICATE_LIB_OK
 deps =
     -rrequirements.txt
+	torch19: torch <= 1.9.0.
     pytest-cov
 commands =
     pytest --cov --cov-append --cov-report term --cov-report html tests/


### PR DESCRIPTION
Fixes #22 .

This PR is necessitated by this PyTorch PR which is now part of 1.10.0 https://github.com/pytorch/pytorch/pull/60982

~~Unfortunately, this PR will break onnx2pytorch for torch<1.10.0, so it is not ready to be merged until I fix this.~~
Edit: this PR now works with torch < 1.10.0 and torch >= 1.10.0.