### PR TITLE
Avoid calling torch.clamp when neither min and max are given

### DIFF
--- a/download_fixtures.sh
+++ b/download_fixtures.sh
@@ -42,6 +42,12 @@ if [[ $1 == "--all" ]]; then
     echo Downloading efficientnet-lite4
     curl -LJo efficientnet-lite4.onnx https://github.com/onnx/models/blob/master/vision/classification/efficientnet-lite4/model/efficientnet-lite4-11.onnx\?raw\=true
   fi
+
+  if [[ ! -f mobilenetv2-7.onnx ]]; then
+    echo Downloading mobilenetv2-7
+    curl -LJo mobilenetv2-7.onnx https://github.com/onnx/models/raw/master/vision/classification/mobilenet/model/mobilenetv2-7.onnx\?raw\=true
+  fi
+ 
 fi
 
 echo "All models downloaded."

--- a/onnx2pytorch/convert/attribute.py
+++ b/onnx2pytorch/convert/attribute.py
@@ -124,6 +124,10 @@ def extract_attributes(node):
             kwargs["largest"] = extract_attr_values(attr)
         elif attr.name == "layout":
             kwargs["layout"] = extract_attr_values(attr)
+        elif attr.name == "max":
+            kwargs["max"] = extract_attr_values(attr)
+        elif attr.name == "min":
+            kwargs["min"] = extract_attr_values(attr)
         elif attr.name == "mode":
             kwargs["mode"] = extract_attr_values(attr)
         elif attr.name == "momentum":

--- a/onnx2pytorch/convert/operations.py
+++ b/onnx2pytorch/convert/operations.py
@@ -93,7 +93,7 @@ def convert_operations(onnx_graph, opset_version, batch_dim=0, enable_pruning=Tr
         elif node.op_type == "Ceil":
             op = OperatorWrapper(torch.ceil)
         elif node.op_type == "Clip":
-            op = OperatorWrapper(torch.clamp)
+            op = Clip(**extract_attributes(node))
         elif node.op_type == "Concat":
             op = partial(torch.cat, **extract_attributes(node))
         elif node.op_type == "Constant":

--- a/onnx2pytorch/operations/__init__.py
+++ b/onnx2pytorch/operations/__init__.py
@@ -2,6 +2,7 @@ from .add import Add
 from .batchnorm import BatchNormWrapper
 from .bitshift import BitShift
 from .cast import Cast
+from .clip import Clip
 from .constant import Constant
 from .constantofshape import ConstantOfShape
 from .div import Div
@@ -41,6 +42,7 @@ __all__ = [
     "BatchNormWrapper",
     "BitShift",
     "Cast",
+    "Clip",
     "Constant",
     "ConstantOfShape",
     "Div",

--- a/onnx2pytorch/operations/batchnorm.py
+++ b/onnx2pytorch/operations/batchnorm.py
@@ -1,7 +1,19 @@
 import warnings
 
 from torch import nn
-from torch.nn.modules.batchnorm import _BatchNorm, _LazyBatchNorm
+from torch.nn.modules.batchnorm import _BatchNorm
+
+try:
+    from torch.nn.modules.batchnorm import _LazyNormBase
+
+    class _LazyBatchNorm(_LazyNormBase, _BatchNorm):
+
+        cls_to_become = _BatchNorm
+
+
+except ImportError:
+    # for torch < 1.10.0
+    from torch.nn.modules.batchnorm import _LazyBatchNorm
 
 
 class LazyBatchNormUnsafe(_LazyBatchNorm):

--- a/onnx2pytorch/operations/clip.py
+++ b/onnx2pytorch/operations/clip.py
@@ -1,0 +1,19 @@
+import torch
+from torch import nn
+
+
+class Clip(nn.Module):
+    def __init__(self, min=None, max=None):
+        super().__init__()
+        self.min = min
+        self.max = max
+
+    def forward(self, input, min=None, max=None):
+        if min is None:
+            min = self.min
+        if max is None:
+            max = self.max
+        if min is None and max is None:
+            return input
+        else:
+            return torch.clamp(input, min=min, max=max)

--- a/onnx2pytorch/operations/instancenorm.py
+++ b/onnx2pytorch/operations/instancenorm.py
@@ -2,71 +2,80 @@ import warnings
 import torch
 
 from torch.nn.modules.instancenorm import _InstanceNorm
-from torch.nn.modules.lazy import LazyModuleMixin
-from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
+
+try:
+    from torch.nn.modules.batchnorm import _LazyNormBase
+
+    class _LazyInstanceNorm(_LazyNormBase, _InstanceNorm):
+
+        cls_to_become = _InstanceNorm
 
 
-class _LazyInstanceNorm(LazyModuleMixin, _InstanceNorm):
+except ImportError:
+    from torch.nn.modules.lazy import LazyModuleMixin
+    from torch.nn.parameter import UninitializedBuffer, UninitializedParameter
 
-    weight: UninitializedParameter  # type: ignore[assignment]
-    bias: UninitializedParameter  # type: ignore[assignment]
+    class _LazyInstanceNorm(LazyModuleMixin, _InstanceNorm):
 
-    cls_to_become = _InstanceNorm
+        weight: UninitializedParameter  # type: ignore[assignment]
+        bias: UninitializedParameter  # type: ignore[assignment]
 
-    def __init__(
-        self,
-        eps=1e-5,
-        momentum=0.1,
-        affine=True,
-        track_running_stats=True,
-        device=None,
-        dtype=None,
-    ) -> None:
-        factory_kwargs = {"device": device, "dtype": dtype}
-        super(_LazyInstanceNorm, self).__init__(
-            # affine and track_running_stats are hardcoded to False to
-            # avoid creating tensors that will soon be overwritten.
-            0,
-            eps,
-            momentum,
-            False,
-            False,
-            **factory_kwargs,
-        )
-        self.affine = affine
-        self.track_running_stats = track_running_stats
-        if self.affine:
-            self.weight = UninitializedParameter(**factory_kwargs)
-            self.bias = UninitializedParameter(**factory_kwargs)
-        if self.track_running_stats:
-            self.running_mean = UninitializedBuffer(**factory_kwargs)
-            self.running_var = UninitializedBuffer(**factory_kwargs)
-            self.num_batches_tracked = torch.tensor(
+        cls_to_become = _InstanceNorm
+
+        def __init__(
+            self,
+            eps=1e-5,
+            momentum=0.1,
+            affine=True,
+            track_running_stats=True,
+            device=None,
+            dtype=None,
+        ) -> None:
+            factory_kwargs = {"device": device, "dtype": dtype}
+            super(_LazyInstanceNorm, self).__init__(
+                # affine and track_running_stats are hardcoded to False to
+                # avoid creating tensors that will soon be overwritten.
                 0,
-                dtype=torch.long,
-                **{k: v for k, v in factory_kwargs.items() if k != "dtype"},
+                eps,
+                momentum,
+                False,
+                False,
+                **factory_kwargs,
             )
-
-    def reset_parameters(self) -> None:
-        if not self.has_uninitialized_params() and self.num_features != 0:
-            super().reset_parameters()
-
-    def initialize_parameters(self, input) -> None:  # type: ignore[override]
-        if self.has_uninitialized_params():
-            self.num_features = input.shape[1]
+            self.affine = affine
+            self.track_running_stats = track_running_stats
             if self.affine:
-                assert isinstance(self.weight, UninitializedParameter)
-                assert isinstance(self.bias, UninitializedParameter)
-                self.weight.materialize((self.num_features,))
-                self.bias.materialize((self.num_features,))
+                self.weight = UninitializedParameter(**factory_kwargs)
+                self.bias = UninitializedParameter(**factory_kwargs)
             if self.track_running_stats:
-                self.running_mean.materialize(
-                    (self.num_features,)
-                )  # type:ignore[union-attr]
-                self.running_var.materialize(
-                    (self.num_features,)
-                )  # type:ignore[union-attr]
-            self.reset_parameters()
+                self.running_mean = UninitializedBuffer(**factory_kwargs)
+                self.running_var = UninitializedBuffer(**factory_kwargs)
+                self.num_batches_tracked = torch.tensor(
+                    0,
+                    dtype=torch.long,
+                    **{k: v for k, v in factory_kwargs.items() if k != "dtype"},
+                )
+
+        def reset_parameters(self) -> None:
+            if not self.has_uninitialized_params() and self.num_features != 0:
+                super().reset_parameters()
+
+        def initialize_parameters(self, input) -> None:  # type: ignore[override]
+            if self.has_uninitialized_params():
+                self.num_features = input.shape[1]
+                if self.affine:
+                    assert isinstance(self.weight, UninitializedParameter)
+                    assert isinstance(self.bias, UninitializedParameter)
+                    self.weight.materialize((self.num_features,))
+                    self.bias.materialize((self.num_features,))
+                if self.track_running_stats:
+                    self.running_mean.materialize(
+                        (self.num_features,)
+                    )  # type:ignore[union-attr]
+                    self.running_var.materialize(
+                        (self.num_features,)
+                    )  # type:ignore[union-attr]
+                self.reset_parameters()
 
 
 class LazyInstanceNormUnsafe(_LazyInstanceNorm):

--- a/tests/onnx2pytorch/operations/test_clip.py
+++ b/tests/onnx2pytorch/operations/test_clip.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+import torch
+
+from onnx2pytorch.operations.clip import Clip
+
+
+def test_clip():
+    x_np = np.random.randn(3, 4, 5).astype(np.float32)
+    x = torch.from_numpy(x_np)
+
+    op = Clip(min=-1, max=1)
+    exp_y_np = np.clip(x_np, -1, 1)
+    exp_y = torch.from_numpy(exp_y_np)
+    assert torch.equal(op(x), exp_y)
+
+    op = Clip(min=0)
+    exp_y_np = np.clip(x_np, 0, np.inf)
+    exp_y = torch.from_numpy(exp_y_np)
+    assert torch.equal(op(x), exp_y)
+
+    op = Clip(max=0)
+    exp_y_np = np.clip(x_np, np.NINF, 0)
+    exp_y = torch.from_numpy(exp_y_np)
+    assert torch.equal(op(x), exp_y)
+
+    op = Clip()
+    exp_y_np = np.clip(x_np, np.NINF, np.inf)
+    exp_y = torch.from_numpy(exp_y_np)
+    assert torch.equal(op(x), exp_y)


### PR DESCRIPTION
The ONNX Clip op can possibly be given neither min nor max, but torch.clamp expects at least one of them to be non-None. This change avoids calling torch.clamp when neither min and max are given.

Also adds mobilenetv2-7 to the fixtures, which exposes this issue.

Resolves #18 