### PR TITLE
PR to add LogSoftmax, and also has some code cleanup

### DIFF
--- a/onnx2pytorch/convert/operations.py
+++ b/onnx2pytorch/convert/operations.py
@@ -240,10 +240,14 @@ def convert_operations(onnx_graph, opset_version, batch_dim=0, enable_pruning=Tr
             kwargs = dict(dim=-1)
             kwargs.update(extract_attributes(node))
             op = nn.Softmax(**kwargs)
+        elif node.op_type == "LogSoftmax":
+            kwargs = dict(dim=-1)
+            kwargs.update(extract_attributes(node))
+            op = nn.LogSoftmax(**kwargs)
         elif node.op_type == "Softplus":
-            op = nn.Softplus(beta=1)
+            op = nn.Softplus(**extract_attributes(node))
         elif node.op_type == "Softsign":
-            op = nn.Softsign()
+            op = nn.Softsign(**extract_attributes(node))
         elif node.op_type == "Split":
             kwargs = extract_attributes(node)
             # if the split_size_or_sections is not in node attributes,

--- a/onnx2pytorch/operations/loop.py
+++ b/onnx2pytorch/operations/loop.py
@@ -1,10 +1,7 @@
 from collections import defaultdict
-from copy import deepcopy
 from functools import partial
 from importlib import import_module
-import warnings
 
-import numpy as np
 import onnx
 import torch
 from onnx import numpy_helper

--- a/onnx2pytorch/operations/loop.py
+++ b/onnx2pytorch/operations/loop.py
@@ -68,7 +68,6 @@ class Loop(nn.Module):
         """
 
         N = len(self.input_names) - 2
-        K = len(self.output_names) - (1 + N)
 
         M = inputs[0]
         cond = inputs[1]


### PR DESCRIPTION
PR summary: 

- Add `LogSoftmax`, used in several SOTA CNN models. 
- Some hyperparameters for Activation operations were hardcoded, taking the values from the `node` now (eg: `Softplus`). 
- Remove unused variables