### PR TITLE
Fix inconsistent padding scheme between onnx and pytorch

### DIFF
--- a/onnx2pytorch/convert/model.py
+++ b/onnx2pytorch/convert/model.py
@@ -202,7 +202,10 @@ class ConvertModel(nn.Module):
                 ]
 
             in_activations = [in_act for in_act in in_activations if in_act is not None]
-
+            if node.op_type == "Pad":
+                # preprocess pad in case it is 8-d array or 6-d array
+                from onnx2pytorch.operations.pad import preprocess_pads
+                in_activations = preprocess_pads(in_activations)
             # store activations for next layer
             if isinstance(op, Loop):
                 outputs = op((self,), activations, *in_activations)

--- a/onnx2pytorch/operations/pad.py
+++ b/onnx2pytorch/operations/pad.py
@@ -3,6 +3,26 @@ import torch.nn.functional as F
 from onnx2pytorch.operations.base import Operator
 
 
+def preprocess_pads(in_activations):
+    """
+    If pads is 8-d array for 4d input or pads is 6-d array for 3d input.
+    Convert pads from [b1,b2,...,e1,e2,...] to [b1,e1,b2,e2,...]
+
+    """
+    input = in_activations[0]
+    pads = list(in_activations[1])
+    if len(pads)//2 == len(input.size()):
+        import torch
+        new_pads = []
+        mid_idx = len(pads)//2
+        pads.reverse()
+        for i in range(mid_idx, len(pads)):
+            new_pads.append(pads[i])
+            new_pads.append(pads[i-mid_idx])
+        in_activations[1] = torch.tensor(new_pads)
+    return in_activations
+
+
 class Pad(Operator):
     def __init__(self, mode="constant", padding=None):
         self.mode = mode


### PR DESCRIPTION
The scheme between torch.nn.functional.Pad and onnx's pad is different if the pads receive 8-dimensional padding.
Given input with size: (1,3,10,10) and `pads=(1,1,2,2,3,3,4,4)`, `F.Pad` will result in size (9,9,14,12) (as declared in your [test scripts](https://github.com/ToriML/onnx2pytorch/blob/master/tests/onnx2pytorch/operations/test_pad.py)). However, onnx will output result with size: (5,7,16,16) following their [documentation](https://github.com/onnx/onnx/blob/main/docs/Operators.md#Pad). 

Therefore, the `pads` parameter loaded from `onnx_model.graph` should be transformed to the PyTorch version so the padding size is correct.

Unfortunately, I find that the `pads` parameter will be placed in `onnx_model.graph.initializer` instead of the node's parameter, so a simple preprocess of Pad nodes' parameter is not feasible :(. 

So I have to add an additional branch (which is ugly...) when loading the initializer parameter: if the targeting node is `Pad` we will check if the pads parameter needs to be preprocessed.

I write a [program](https://colab.research.google.com/drive/1BvPCG1cR43KJXesCrlb8qsuuYU_PHXhm?usp=sharing) to exhibit this bug:
Through this code snippet, we can see that the correct output shape should be: `(batch_size, 226, 226, 3)` but ONNX2PyTorch will output `(batch_size+1, 225, 225, 3)` 

Current fix can pass all existing tests.